### PR TITLE
added support for multiple directories in $PHP_VERSIONS

### DIFF
--- a/php-version.sh
+++ b/php-version.sh
@@ -20,17 +20,23 @@ function php-version {
   # local variables
   local _PHP_VERSION=$1
   local _PHP_VERSIONS=${PHP_VERSIONS-''}
-  local _PHP_ROOT=${_PHP_VERSIONS}/${_PHP_VERSION}
 
   # bail-out if _PHP_VERSIONS does not exist
-  if [[ ! -d ${_PHP_VERSIONS} ]]; then
-    echo "Sorry, but ${PROGRAM_APPNAME} requires that \$PHP_VERSIONS is set and points to an existing directory." >&2
+  if [[ -z ${_PHP_VERSIONS} ]]; then
+    echo "Sorry, but ${PROGRAM_APPNAME} requires that \$PHP_VERSIONS is set and points to an existing directory or directories." >&2
     return 1
   fi
 
+  for _PHP_REPOSITORY in $_PHP_VERSIONS; do
+    if [[ -d ${_PHP_REPOSITORY}/${_PHP_VERSION} ]]; then
+      local _PHP_ROOT=${_PHP_REPOSITORY}/${_PHP_VERSION}
+      break;
+    fi
+  done
+
   # bail-out if _PHP_ROOT does not exist
-  if [[ ! -d $_PHP_ROOT ]]; then
-    echo "Sorry, but ${PROGRAM_VERSION} was unable to find directory '${_PHP_VERSION}' under '${_PHP_VERSIONS}'." >&2
+  if [[ -z $_PHP_ROOT ]]; then
+    echo "Sorry, but ${PROGRAM_APPNAME} was unable to find directory '${_PHP_VERSION}' under '${_PHP_VERSIONS}'." >&2
     return 1
   fi
 
@@ -61,7 +67,7 @@ function php-version {
 # shell completion for php-version function
 ################################################################################
 
-if [[ ! -d ${PHP_VERSIONS} ]]; then
+if [[ -z ${PHP_VERSIONS} ]]; then
   echo "Sorry, but php-version requires that the environment variable \$PHP_VERSIONS is set in order to initialize bash completion." >&2
   return 1
 fi
@@ -74,7 +80,10 @@ fi
 if [[ -n ${BASH_VERSION-""} ]]; then
   _phpversions() {
     local CURRENTWD="${COMP_WORDS[COMP_CWORD]}"
-    COMPREPLY=( $(compgen -d ${PHP_VERSIONS%/}/${CURRENTWD} | tr -d ${PHP_VERSIONS%/}/ | grep -vi "${PHP_VERSION}\$") )
+    COMPREPLY=()
+    for _PHP_REPOSITORY in $PHP_VERSIONS; do
+      COMPREPLY=("${COMPREPLY[@]}" $(compgen -d ${_PHP_REPOSITORY%/}/${CURRENTWD} | sed "s#${_PHP_REPOSITORY%/}/##g" ))
+    done
   }
 
   complete -o nospace -F _phpversions php-version


### PR DESCRIPTION
Sometimes you have your different PHP versions installed in different directories.
For example, if you install PHP 5.3.21 and PHP 5.4.11 with homebrew (and you don't want to mess your FS with symlinks), you will have the below structure:
- /usr/local/Cellar/php53/5.3.21
- /usr/local/Cellar/php54/5.4.11

You can even image, want to have 5.3.21 and 5.4.10 installed with homebrew, and compile your own PHP version with debug symbols.
Looking for the right PHP version in multiple directories allow you that without having to simlink everything in the right directory.
