### PR TITLE
Fixed snap versioning

### DIFF
--- a/php-version.sh
+++ b/php-version.sh
@@ -44,7 +44,7 @@ function php-version {
 
     "")
 
-      _PHP_REPOSITORY=$(find $_PHP_VERSIONS -type d -maxdepth 1 -mindepth 1 -exec basename {} \; 2>/dev/null | sort -r -t . -k 1,1n -k 2,2n -k 3,3n)
+      _PHP_REPOSITORY=$(find $_PHP_VERSIONS -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null | sort -r -t . -k 1,1n -k 2,2n -k 3,3n)
 
       for version in $_PHP_REPOSITORY; do
         local selected=" "
@@ -73,7 +73,7 @@ function php-version {
 
   # try a fuzzy match since we were unable to find a PHP matching given version
   if [[ -z $_PHP_ROOT ]]; then
-    _PHP_VERSION=$(find $_PHP_VERSIONS -type d -maxdepth 1 -mindepth 1 -exec basename {} \; 2>/dev/null | sort -r -t . -k 1,1n -k 2,2n -k 3,3n | grep $_PHP_VERSION 2>/dev/null | tail -1)
+    _PHP_VERSION=$(find $_PHP_VERSIONS -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null | sort -r -t . -k 1,1n -k 2,2n -k 3,3n | grep ^$_PHP_VERSION 2>/dev/null | tail -1)
 
     for _PHP_REPOSITORY in $_PHP_VERSIONS; do
       if [[ -n "$_PHP_VERSION" && -d $_PHP_REPOSITORY/$_PHP_VERSION ]]; then


### PR DESCRIPTION
I have found a bug in the snap versioning feature. After compiled php 5.3.27 and 5.5.3 and wanted to select 5.3 I got this:

```
$ php-version 5.3
SWITCHED PHP VERSION TO: 5.5.3
NEW PHP ROOT DIRECTORY : /opt/php/versions/5.5.3
```

When I entered the find separately I got this:

```
$ find $PHP_VERSIONS -type d -maxdepth 1 -mindepth 1 -exec basename {} \; | grep 5.3

find: warning: you have specified the -maxdepth option after a non-option argument -type, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.

find: warning: you have specified the -mindepth option after a non-option argument -type, but options are not positional (-mindepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.

5.5.3
5.3.27
```

The grep matched 5. **5.3** and **5.3** .27. With this patch the grep matches from the beginning of the string and also fixed the warning.
