### PR TITLE
Fix for change in location of homebrew php folders

### DIFF
--- a/php-version.sh
+++ b/php-version.sh
@@ -28,7 +28,7 @@ function php-version {
 
   # add default Homebrew directories if brew is installed
   if [[ -n $(command -v brew) ]]; then
-    export _PHP_VERSIONS="$_PHP_VERSIONS $(echo $(find $(brew --cellar) -maxdepth 1 -type d | $grep 'php[0-9]*$'))"
+    export _PHP_VERSIONS="$_PHP_VERSIONS $(echo $(find $(brew --cellar) -maxdepth 1 -type l | $grep 'php[0-9]*$'))"
   fi
 
   # add extra directories if configured
@@ -103,7 +103,7 @@ function php-version {
       # Loop through all repositories and get every single php-version
       _PHP_VERSIONS=()
       for _PHP_REPOSITORY in "${_PHP_REPOSITORIES[@]}"; do
-        for _dir in $(find $(echo $_PHP_REPOSITORY) -maxdepth 1 -mindepth 1 -type d 2>/dev/null); do
+        for _dir in $(find -H $(echo $_PHP_REPOSITORY) -maxdepth 1 -mindepth 1 -type d 2>/dev/null); do
           _PHP_VERSIONS=("${_PHP_VERSIONS[@]}" "$($_dir/bin/php-config --version 2>/dev/null)")
         done
       done
@@ -140,7 +140,7 @@ function php-version {
     _TARGET_VERSION_FUZZY=()
 
     for _PHP_REPOSITORY in "${_PHP_REPOSITORIES[@]}"; do
-      for _dir in $(find $_PHP_REPOSITORY -maxdepth 1 -mindepth 1 -type d 2>/dev/null); do
+      for _dir in $(find -H $_PHP_REPOSITORY -maxdepth 1 -mindepth 1 -type d 2>/dev/null); do
         _TARGET_VERSION_FUZZY=("${_TARGET_VERSION_FUZZY[@]}" "$($_dir/bin/php-config --version 2>/dev/null)")
       done
     done
@@ -148,7 +148,7 @@ function php-version {
     _TARGET_VERSION_FUZZY=$(IFS=$'\n'; echo "${_TARGET_VERSION_FUZZY[*]}" | eval $sort | eval "$grep '^$_TARGET_VERSION' 2>/dev/null" | tail -1)
 
     for _PHP_REPOSITORY in "${_PHP_REPOSITORIES[@]}"; do
-      for _dir in $(find $_PHP_REPOSITORY -maxdepth 1 -mindepth 1 -type d 2>/dev/null); do
+      for _dir in $(find -H $_PHP_REPOSITORY -maxdepth 1 -mindepth 1 -type d 2>/dev/null); do
         _PHP_VERSION="$($_dir/bin/php-config --version 2>/dev/null)"
         if [[ -n "$_TARGET_VERSION_FUZZY" && "$_PHP_VERSION" == "$_TARGET_VERSION_FUZZY" ]]; then
           local _PHP_ROOT=$_dir

--- a/php-version.sh
+++ b/php-version.sh
@@ -17,10 +17,6 @@ function php-version {
   # PHP installation paths
   local _PHP_VERSIONS=""
 
-  # use builtin commands for sort and grep
-  local grep="command grep -E"
-  local sort="command sort -r -t . -k 1,1n -k 2,2n -k 3,3n"
-
   # add ~/.phps if it exists (default)
   if [[ -d $HOME/.phps ]]; then
     export _PHP_VERSIONS="$_PHP_VERSIONS $HOME/.phps"
@@ -28,7 +24,7 @@ function php-version {
 
   # add default Homebrew directories if brew is installed
   if [[ -n $(command -v brew) ]]; then
-    export _PHP_VERSIONS="$_PHP_VERSIONS $(echo $(find $(brew --cellar) -maxdepth 1 -type l | $grep 'php[0-9]*$'))"
+    export _PHP_VERSIONS="$_PHP_VERSIONS $(echo $(find $(brew --cellar) -maxdepth 1 -type l | grep -E 'php[0-9]*$'))"
   fi
 
   # add extra directories if configured
@@ -108,7 +104,7 @@ function php-version {
         done
       done
 
-      _PHP_VERSIONS=$(IFS=$'\n'; echo "${_PHP_VERSIONS[*]}" | eval $sort)
+      _PHP_VERSIONS=$(IFS=$'\n'; echo "${_PHP_VERSIONS[*]}" | sort -r -t . -k 1,1n -k 2,2n -k 3,3n)
 
       for version in $(echo $_PHP_VERSIONS | tr " " "\n"); do
         local selected=" "
@@ -145,7 +141,7 @@ function php-version {
       done
     done
 
-    _TARGET_VERSION_FUZZY=$(IFS=$'\n'; echo "${_TARGET_VERSION_FUZZY[*]}" | eval $sort | eval "$grep '^$_TARGET_VERSION' 2>/dev/null" | tail -1)
+    _TARGET_VERSION_FUZZY=$(IFS=$'\n'; echo "${_TARGET_VERSION_FUZZY[*]}" | sort -r -t . -k 1,1n -k 2,2n -k 3,3n | grep -E "^$_TARGET_VERSION" 2>/dev/null | tail -1)
 
     for _PHP_REPOSITORY in "${_PHP_REPOSITORIES[@]}"; do
       for _dir in $(find -H $_PHP_REPOSITORY -maxdepth 1 -mindepth 1 -type d 2>/dev/null); do


### PR DESCRIPTION
Fixes issue #65 
This was only tested on El Capitan with PHP5.6, PHP7.1, and PHP7.2

It builds the list of PHP folders from the PHP symlinks in brew --cellar rather than from the now missing php directories. It then searches the symlinked folders for the installed PHP versions.

Not sure how robust this is, but it seems to work fine for me.